### PR TITLE
feat: add movie search and popular endpoints with tests and OpenAPI docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ yarn-error.log
 
 # Coverage
 coverage/
+
+# Claude Code
+CLAUDE.md

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16,8 +16,124 @@ servers:
 tags:
   - name: Health
     description: Public service status routes
+  - name: Movies
+    description: Movie search and discovery routes
 
 paths:
+  /movies/search:
+    get:
+      tags: [Movies]
+      summary: Search movies by title
+      description: Searches TMDB for movies matching the given title and returns a transformed paginated list. Raw TMDB fields are never exposed.
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: The movie title to search for
+          schema:
+            type: string
+          example: Fight Club
+        - name: page
+          in: query
+          required: false
+          description: Page number of results to return. Must be a positive integer. Defaults to 1.
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          example: 1
+      responses:
+        '200':
+          description: Paginated list of matching movies
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MediaListResponse'
+              example:
+                page: 1
+                totalPages: 5
+                totalResults: 92
+                results:
+                  - id: 550
+                    title: Fight Club
+                    year: 1999
+                    posterUrl: https://image.tmdb.org/t/p/w500/example.jpg
+                    overview: An insomniac office worker crosses paths with a soap maker.
+                    mediaType: movie
+        '400':
+          description: Missing or invalid query parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                missingQ:
+                  summary: Missing q parameter
+                  value:
+                    error: Query parameter q is required
+                invalidPage:
+                  summary: Invalid page parameter
+                  value:
+                    error: Query parameter page must be a positive integer
+        '502':
+          description: TMDB upstream failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: TMDB request failed with status 500
+
+  /movies/popular:
+    get:
+      tags: [Movies]
+      summary: Get popular movies
+      description: Returns the current list of popular movies from TMDB as a transformed paginated list. Raw TMDB fields are never exposed.
+      parameters:
+        - name: page
+          in: query
+          required: false
+          description: Page number of results to return. Must be a positive integer. Defaults to 1.
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          example: 1
+      responses:
+        '200':
+          description: Paginated list of popular movies
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MediaListResponse'
+              example:
+                page: 1
+                totalPages: 500
+                totalResults: 10000
+                results:
+                  - id: 1396
+                    title: Breaking Bad
+                    year: 2008
+                    posterUrl: https://image.tmdb.org/t/p/w500/example.jpg
+                    overview: A chemistry teacher diagnosed with cancer turns to manufacturing drugs.
+                    mediaType: movie
+        '400':
+          description: Invalid page parameter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Query parameter page must be a positive integer
+        '502':
+          description: TMDB upstream failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: TMDB request failed with status 500
+
   /health:
     get:
       tags: [Health]
@@ -40,3 +156,66 @@ paths:
                 required:
                   - status
                   - service
+
+components:
+  schemas:
+    MediaListItem:
+      type: object
+      required: [id, title, year, posterUrl, overview, mediaType]
+      properties:
+        id:
+          type: integer
+          description: TMDB numeric ID
+          example: 550
+        title:
+          type: string
+          description: Movie title
+          example: Fight Club
+        year:
+          type: integer
+          nullable: true
+          description: Year extracted from release date, null if unavailable
+          example: 1999
+        posterUrl:
+          type: string
+          nullable: true
+          description: Full poster image URL at w500 size, null if no poster
+          example: https://image.tmdb.org/t/p/w500/example.jpg
+        overview:
+          type: string
+          description: Short movie description
+          example: An insomniac office worker crosses paths with a soap maker.
+        mediaType:
+          type: string
+          enum: [movie]
+          description: Always "movie" for movie results
+
+    MediaListResponse:
+      type: object
+      required: [page, totalPages, totalResults, results]
+      properties:
+        page:
+          type: integer
+          description: Current page number
+          example: 1
+        totalPages:
+          type: integer
+          description: Total number of pages available
+          example: 5
+        totalResults:
+          type: integer
+          description: Total number of results across all pages
+          example: 92
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/MediaListItem'
+
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+          description: Human-readable error message
+          example: Query parameter q is required

--- a/src/controllers/movies.ts
+++ b/src/controllers/movies.ts
@@ -1,0 +1,96 @@
+import { Request, Response, NextFunction } from 'express';
+import { getTmdbConfig } from '../config/env';
+import { HttpError } from '../errors/http-error';
+import { tmdbClient } from '../services/tmdb-client';
+// Pull in the helper that turns "1999-10-15" into the number 1999 (or null if missing)
+import { extractYear } from '../utils/extract-year';
+// Pull in the helper that builds a full image URL from a raw TMDB path like "/abc.jpg"
+import { buildTmdbImageUrl } from '../utils/tmdb-image';
+// MediaListItem = the shape of one item in your API's response
+// MediaListResponse = the shape of the full paginated response your API returns
+// TmdbListResponse = the shape of the raw paginated response TMDB sends back
+// TmdbMovieListResult = the shape of one raw movie item TMDB sends back
+import {
+  MediaListItem,
+  MediaListResponse,
+  TmdbListResponse,
+  TmdbMovieListResult,
+} from '../types/media';
+
+// Takes one raw TMDB movie object and one base URL string, returns one clean MediaListItem
+export const toMovieListItem = (
+  raw: TmdbMovieListResult, // the raw TMDB object e.g. { id, title, poster_path, release_date, overview }
+  imageBaseUrl: string // e.g. "https://image.tmdb.org/t/p" — passed in so this stays a pure function
+): MediaListItem => ({
+  id: raw.id, // TMDB id stays as-is, just copied directly
+  mediaType: 'movie', // hardcoded — this transformer is only ever called for movies, never shows
+  overview: raw.overview, // TMDB overview stays as-is, just copied directly
+  // buildTmdbImageUrl combines imageBaseUrl + "w500" + raw.poster_path into a full URL
+  // returns null if poster_path is null (some movies have no poster)
+  posterUrl: buildTmdbImageUrl(imageBaseUrl, raw.poster_path, 'w500'),
+  title: raw.title, // TMDB title stays as-is, just copied directly
+  // extractYear slices the first 4 characters of "1999-10-15" and parses to integer 1999
+  // returns null if release_date is missing or not a valid date string
+  year: extractYear(raw.release_date),
+});
+
+// Takes the full raw TMDB paginated response and returns your API's paginated response shape
+export const toMovieListResponse = (
+  raw: TmdbListResponse<TmdbMovieListResult>, // the full TMDB response with page, results[], total_pages, total_results
+  imageBaseUrl: string // passed through to toMovieListItem for each result
+): MediaListResponse => ({
+  page: raw.page, // current page number, same field name so just copied
+  // raw.results is an array of TMDB movie objects — map each one through toMovieListItem
+  // this is where all the field renaming and URL building happens for every item
+  results: raw.results.map((item) => toMovieListItem(item, imageBaseUrl)),
+  totalPages: raw.total_pages, // TMDB uses snake_case — your API uses camelCase, renamed here
+  totalResults: raw.total_results, // same rename: total_results → totalResults
+});
+
+export const searchMovies = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  const q = req.query.q;
+  if (!q || typeof q !== 'string') {
+    next(new HttpError(400, 'Query parameter q is required'));
+    return;
+  }
+
+  const page = req.query.page !== undefined ? Number(req.query.page) : 1;
+  if (!Number.isInteger(page) || page < 1) {
+    next(new HttpError(400, 'Query parameter page must be a positive integer'));
+    return;
+  }
+
+  try {
+    const { imageBaseUrl } = getTmdbConfig();
+    const data = await tmdbClient.searchMovies(q, page);
+    res.json(toMovieListResponse(data, imageBaseUrl));
+  } catch (error) {
+    next(error);
+  }
+};
+
+// Handles GET /movies/popular?page={number}
+export const getPopularMovies = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  // default to page 1 if not provided
+  const page = req.query.page !== undefined ? Number(req.query.page) : 1;
+  if (!Number.isInteger(page) || page < 1) {
+    next(new HttpError(400, 'Query parameter page must be a positive integer'));
+    return;
+  }
+
+  try {
+    const { imageBaseUrl } = getTmdbConfig();
+    const data = await tmdbClient.getPopularMovies(page); // calls TMDB /movie/popular
+    res.json(toMovieListResponse(data, imageBaseUrl)); // same transformer as search
+  } catch (error) {
+    next(error); // HttpError flows to errorHandler
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import { app } from './app';
 const PORT = parseInt(process.env.PORT || '3000', 10);
 
 app.listen(PORT, () => {
+  // eslint-disable-next-line no-console
   console.log(`Server running at http://localhost:${PORT}`);
+  // eslint-disable-next-line no-console
   console.log(`API docs at http://localhost:${PORT}/api-docs`);
 });

--- a/src/middleware/logger.ts
+++ b/src/middleware/logger.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 
 export const logger = (request: Request, _response: Response, next: NextFunction) => {
   const timestamp = new Date().toISOString();
+  // eslint-disable-next-line no-console
   console.log(`[${timestamp}] ${request.method} ${request.path}`);
   next();
 };

--- a/src/routes/movies.ts
+++ b/src/routes/movies.ts
@@ -1,17 +1,14 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { HttpError } from '../errors/http-error';
+import { getPopularMovies, searchMovies } from '../controllers/movies';
 
 const router = Router();
 
 // GET /movies/search?q={title}&page={number}
-router.get('/search', (_request: Request, _response: Response, next: NextFunction) => {
-  next(new HttpError(501, 'Not Implemented'));
-});
+router.get('/search', searchMovies);
 
 // GET /movies/popular?page={number}
-router.get('/popular', (_request: Request, _response: Response, next: NextFunction) => {
-  next(new HttpError(501, 'Not Implemented'));
-});
+router.get('/popular', getPopularMovies);
 
 // GET /movies/:id
 router.get('/:id', (_request: Request, _response: Response, next: NextFunction) => {

--- a/tests/movies.test.ts
+++ b/tests/movies.test.ts
@@ -1,0 +1,291 @@
+import request from 'supertest';
+import { app } from '../src/app';
+
+// Replace the global fetch with a mock so we never call real TMDB in tests
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+beforeEach(() => {
+  // Reset the mock before each test so one test cannot affect another
+  mockFetch.mockReset();
+  // Provide a fake API key so getTmdbConfig() does not throw
+  process.env.TMDB_API_KEY = 'test-api-key';
+});
+
+// ---------------------------------------------------------------------------
+// Shared TMDB response shapes (based on API design doc, not implementation)
+// ---------------------------------------------------------------------------
+
+// What TMDB sends back for a movie list item (raw, snake_case)
+const tmdbMovieListItem = {
+  id: 550,
+  title: 'Fight Club',
+  release_date: '1999-10-15',
+  poster_path: '/example.jpg',
+  overview: 'An insomniac office worker crosses paths with a soap maker.',
+};
+
+// What TMDB sends back for a paginated list
+const tmdbListPage = (results: unknown[]) => ({
+  page: 1,
+  total_pages: 5,
+  total_results: 92,
+  results,
+});
+
+// What our API contract says the response must look like (camelCase, full URLs)
+const expectedListItem = {
+  id: 550,
+  title: 'Fight Club',
+  year: 1999,
+  posterUrl: 'https://image.tmdb.org/t/p/w500/example.jpg',
+  overview: 'An insomniac office worker crosses paths with a soap maker.',
+  mediaType: 'movie',
+};
+
+const expectedListResponse = {
+  page: 1,
+  totalPages: 5,
+  totalResults: 92,
+  results: [expectedListItem],
+};
+
+// Helper: make fetch resolve with a successful TMDB list response
+const mockTmdbSuccess = (results: unknown[]) => {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => tmdbListPage(results),
+  });
+};
+
+// Helper: make fetch reject entirely (network down, DNS failure, etc.)
+const mockTmdbNetworkFailure = () => {
+  mockFetch.mockRejectedValue(new Error('Network error'));
+};
+
+// Helper: make fetch resolve but with a TMDB server error
+const mockTmdbServerError = () => {
+  mockFetch.mockResolvedValue({
+    ok: false,
+    status: 500,
+    json: async () => ({ status_message: 'Internal error' }),
+  });
+};
+
+// ---------------------------------------------------------------------------
+// GET /movies/search
+// Spec: q required, page optional positive integer, default 1
+// ---------------------------------------------------------------------------
+
+describe('GET /movies/search', () => {
+  it('200 — returns transformed list when q is provided', async () => {
+    mockTmdbSuccess([tmdbMovieListItem]);
+
+    const res = await request(app).get('/movies/search?q=Fight+Club');
+
+    // Spec says 200 with { page, totalPages, totalResults, results[] }
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(expectedListResponse);
+  });
+
+  it('200 — each result contains all required spec fields', async () => {
+    mockTmdbSuccess([tmdbMovieListItem]);
+
+    const res = await request(app).get('/movies/search?q=Fight+Club');
+
+    const item = res.body.results[0];
+    // Spec requires: id, title, year, posterUrl, overview, mediaType
+    expect(item).toHaveProperty('id');
+    expect(item).toHaveProperty('title');
+    expect(item).toHaveProperty('year');
+    expect(item).toHaveProperty('posterUrl');
+    expect(item).toHaveProperty('overview');
+    expect(item).toHaveProperty('mediaType');
+  });
+
+  it('200 — mediaType is always "movie", never raw TMDB field names', async () => {
+    mockTmdbSuccess([tmdbMovieListItem]);
+
+    const res = await request(app).get('/movies/search?q=Fight+Club');
+
+    const item = res.body.results[0];
+    // Spec says mediaType must be "movie" for movie results
+    expect(item.mediaType).toBe('movie');
+    // Raw TMDB fields must never leak into the response
+    expect(item).not.toHaveProperty('release_date');
+    expect(item).not.toHaveProperty('poster_path');
+    expect(item).not.toHaveProperty('vote_average');
+  });
+
+  it('200 — posterUrl is a full URL, not a raw TMDB path', async () => {
+    mockTmdbSuccess([tmdbMovieListItem]);
+
+    const res = await request(app).get('/movies/search?q=Fight+Club');
+
+    // Spec says posterUrl must be the full image URL, not just "/example.jpg"
+    expect(res.body.results[0].posterUrl).toMatch(/^https:\/\/image\.tmdb\.org/);
+  });
+
+  it('200 — page 2 is accepted and passed through', async () => {
+    mockTmdbSuccess([tmdbMovieListItem]);
+
+    const res = await request(app).get('/movies/search?q=Fight+Club&page=2');
+
+    expect(res.status).toBe(200);
+  });
+
+  it('400 — missing q returns error with message', async () => {
+    const res = await request(app).get('/movies/search');
+
+    // Spec: q is required — missing it must return 400
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — empty q returns error', async () => {
+    const res = await request(app).get('/movies/search?q=');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — non-integer page returns error', async () => {
+    const res = await request(app).get('/movies/search?q=Fight+Club&page=abc');
+
+    // Spec: page must be a positive integer
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — page 0 returns error', async () => {
+    const res = await request(app).get('/movies/search?q=Fight+Club&page=0');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — negative page returns error', async () => {
+    const res = await request(app).get('/movies/search?q=Fight+Club&page=-1');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('502 — TMDB network failure returns upstream error', async () => {
+    mockTmdbNetworkFailure();
+
+    const res = await request(app).get('/movies/search?q=Fight+Club');
+
+    // Spec: upstream failure must return 502
+    expect(res.status).toBe(502);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('502 — TMDB server error returns upstream error', async () => {
+    mockTmdbServerError();
+
+    const res = await request(app).get('/movies/search?q=Fight+Club');
+
+    expect(res.status).toBe(502);
+    expect(res.body).toHaveProperty('error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /movies/popular
+// Spec: page optional positive integer, default 1, no required params
+// ---------------------------------------------------------------------------
+
+describe('GET /movies/popular', () => {
+  it('200 — returns transformed list with no parameters', async () => {
+    mockTmdbSuccess([tmdbMovieListItem]);
+
+    const res = await request(app).get('/movies/popular');
+
+    // Spec says 200 with { page, totalPages, totalResults, results[] }
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(expectedListResponse);
+  });
+
+  it('200 — each result contains all required spec fields', async () => {
+    mockTmdbSuccess([tmdbMovieListItem]);
+
+    const res = await request(app).get('/movies/popular');
+
+    const item = res.body.results[0];
+    expect(item).toHaveProperty('id');
+    expect(item).toHaveProperty('title');
+    expect(item).toHaveProperty('year');
+    expect(item).toHaveProperty('posterUrl');
+    expect(item).toHaveProperty('overview');
+    expect(item).toHaveProperty('mediaType');
+  });
+
+  it('200 — mediaType is always "movie", never raw TMDB field names', async () => {
+    mockTmdbSuccess([tmdbMovieListItem]);
+
+    const res = await request(app).get('/movies/popular');
+
+    const item = res.body.results[0];
+    expect(item.mediaType).toBe('movie');
+    expect(item).not.toHaveProperty('release_date');
+    expect(item).not.toHaveProperty('poster_path');
+    expect(item).not.toHaveProperty('vote_average');
+  });
+
+  it('200 — posterUrl is a full URL, not a raw TMDB path', async () => {
+    mockTmdbSuccess([tmdbMovieListItem]);
+
+    const res = await request(app).get('/movies/popular');
+
+    expect(res.body.results[0].posterUrl).toMatch(/^https:\/\/image\.tmdb\.org/);
+  });
+
+  it('200 — page 2 is accepted', async () => {
+    mockTmdbSuccess([tmdbMovieListItem]);
+
+    const res = await request(app).get('/movies/popular?page=2');
+
+    expect(res.status).toBe(200);
+  });
+
+  it('400 — non-integer page returns error', async () => {
+    const res = await request(app).get('/movies/popular?page=abc');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — page 0 returns error', async () => {
+    const res = await request(app).get('/movies/popular?page=0');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — negative page returns error', async () => {
+    const res = await request(app).get('/movies/popular?page=-1');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('502 — TMDB network failure returns upstream error', async () => {
+    mockTmdbNetworkFailure();
+
+    const res = await request(app).get('/movies/popular');
+
+    expect(res.status).toBe(502);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('502 — TMDB server error returns upstream error', async () => {
+    mockTmdbServerError();
+
+    const res = await request(app).get('/movies/popular');
+
+    expect(res.status).toBe(502);
+    expect(res.body).toHaveProperty('error');
+  });
+});


### PR DESCRIPTION
## What this does
- Adds GET /movies/search?q={title}&page={number}
- Adds GET /movies/popular?page={number}
- Both endpoints transform raw TMDB data into our API schema (no raw TMDB fields exposed)

## Changes
- src/controllers/movies.ts — transformer functions and route handlers
- src/routes/movies.ts — wired search and popular routes
- tests/movies.test.ts — Jest/Supertest tests for both endpoints
- openapi.yaml — documented both routes with request params, response schemas, and error cases

## Tests
- Run npm test to verify all tests pass

## Notes
- TMDB_API_KEY must be set in .env to run locally
- Movie details endpoint (GET /movies/:id) is still stubbed — coming in a future PR