### PR TITLE
feat(ratings): tests, OpenAPI docs, and Sprint 2 auth wiring

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -19,6 +19,8 @@ tags:
     description: Movie routes proxied from TMDB
   - name: Shows
     description: TV show routes proxied from TMDB
+  - name: Ratings
+    description: User ratings for movies and TV shows
 
 paths:
   /health:
@@ -806,6 +808,372 @@ paths:
                   value:
                     error: TMDB request failed
 
+  /api/v1/ratings:
+    get:
+      tags: [Ratings]
+      summary: List ratings
+      description: Returns a paginated list of ratings. All filters are optional.
+      parameters:
+        - in: query
+          name: page
+          required: false
+          description: Page number. Defaults to 1.
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          example: 1
+        - in: query
+          name: pageSize
+          required: false
+          description: Results per page. Defaults to 10, max 50.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 10
+          example: 10
+        - in: query
+          name: tmdbId
+          required: false
+          description: Filter by TMDB identifier.
+          schema:
+            type: integer
+            minimum: 1
+          example: 550
+        - in: query
+          name: mediaType
+          required: false
+          description: Filter by media type.
+          schema:
+            type: string
+            enum: [movie, show]
+          example: movie
+        - in: query
+          name: userId
+          required: false
+          description: Filter by author user ID.
+          schema:
+            type: integer
+            minimum: 1
+          example: 1
+      responses:
+        '200':
+          description: Paginated list of ratings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RatingListResponse'
+              examples:
+                success:
+                  value:
+                    page: 1
+                    pageSize: 10
+                    totalPages: 1
+                    totalResults: 1
+                    results:
+                      - id: 1
+                        tmdbId: 550
+                        mediaType: movie
+                        score: 8
+                        createdAt: "2026-01-01T00:00:00.000Z"
+                        updatedAt: "2026-01-01T00:00:00.000Z"
+                        author:
+                          id: 1
+                          username: alice
+        '400':
+          description: Invalid query parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              examples:
+                invalidPage:
+                  value:
+                    error: Query parameter page must be a positive integer
+                invalidPageSize:
+                  value:
+                    error: Query parameter pageSize must be 50 or less
+                invalidMediaType:
+                  value:
+                    error: Query parameter mediaType must be either movie or show
+
+    post:
+      tags: [Ratings]
+      summary: Create a rating
+      description: >
+        Submits a rating for a TMDB title. Requires authentication.
+        One rating per user per title — returns 409 if the user has already rated this item.
+        The author is always taken from the JWT; never send a userId in the body.
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - tmdbId
+                - mediaType
+                - score
+              properties:
+                tmdbId:
+                  type: integer
+                  minimum: 1
+                  example: 550
+                mediaType:
+                  type: string
+                  enum: [movie, show]
+                  example: movie
+                score:
+                  type: integer
+                  minimum: 1
+                  maximum: 10
+                  example: 8
+            example:
+              tmdbId: 550
+              mediaType: movie
+              score: 8
+      responses:
+        '201':
+          description: Rating created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RatingResponse'
+              examples:
+                success:
+                  value:
+                    id: 1
+                    tmdbId: 550
+                    mediaType: movie
+                    score: 8
+                    createdAt: "2026-01-01T00:00:00.000Z"
+                    updatedAt: "2026-01-01T00:00:00.000Z"
+                    author:
+                      id: 1
+                      username: alice
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              examples:
+                invalidTmdbId:
+                  value:
+                    error: tmdbId must be a positive integer
+                invalidMediaType:
+                  value:
+                    error: mediaType must be either movie or show
+                invalidScore:
+                  value:
+                    error: score must be an integer between 1 and 10
+        '401':
+          description: Missing or invalid token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              examples:
+                missingToken:
+                  value:
+                    error: Missing or malformed Authorization header
+                expiredToken:
+                  value:
+                    error: Invalid or expired token
+        '409':
+          description: User has already rated this item
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              examples:
+                duplicate:
+                  value:
+                    error: You have already rated this item
+
+  /api/v1/ratings/{id}:
+    get:
+      tags: [Ratings]
+      summary: Get a rating by ID
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          example: 1
+      responses:
+        '200':
+          description: Rating found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RatingResponse'
+              examples:
+                success:
+                  value:
+                    id: 1
+                    tmdbId: 550
+                    mediaType: movie
+                    score: 8
+                    createdAt: "2026-01-01T00:00:00.000Z"
+                    updatedAt: "2026-01-01T00:00:00.000Z"
+                    author:
+                      id: 1
+                      username: alice
+        '404':
+          description: Rating not found or invalid ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              examples:
+                notFound:
+                  value:
+                    error: Rating not found
+
+    put:
+      tags: [Ratings]
+      summary: Update a rating
+      description: Updates the score on a rating. Only the original author can update.
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - score
+              properties:
+                score:
+                  type: integer
+                  minimum: 1
+                  maximum: 10
+                  example: 9
+            example:
+              score: 9
+      responses:
+        '200':
+          description: Rating updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RatingResponse'
+              examples:
+                success:
+                  value:
+                    id: 1
+                    tmdbId: 550
+                    mediaType: movie
+                    score: 9
+                    createdAt: "2026-01-01T00:00:00.000Z"
+                    updatedAt: "2026-01-02T00:00:00.000Z"
+                    author:
+                      id: 1
+                      username: alice
+        '400':
+          description: Invalid score
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              examples:
+                invalidScore:
+                  value:
+                    error: score must be an integer between 1 and 10
+        '401':
+          description: Missing or invalid token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              examples:
+                missingToken:
+                  value:
+                    error: Missing or malformed Authorization header
+        '403':
+          description: Authenticated user does not own this rating
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              examples:
+                forbidden:
+                  value:
+                    error: You do not have permission to modify this resource
+        '404':
+          description: Rating not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              examples:
+                notFound:
+                  value:
+                    error: Rating not found
+
+    delete:
+      tags: [Ratings]
+      summary: Delete a rating
+      description: Deletes a rating. Only the original author can delete their rating.
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          example: 1
+      responses:
+        '204':
+          description: Rating deleted
+        '401':
+          description: Missing or invalid token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              examples:
+                missingToken:
+                  value:
+                    error: Missing or malformed Authorization header
+        '403':
+          description: Authenticated user does not own this rating
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              examples:
+                forbidden:
+                  value:
+                    error: You do not have permission to modify this resource
+        '404':
+          description: Rating not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              examples:
+                notFound:
+                  value:
+                    error: Rating not found
+
 components:
   schemas:
     ApiErrorResponse:
@@ -980,3 +1348,83 @@ components:
           type: number
           format: float
           example: 8.9
+
+    RatingResponse:
+      type: object
+      required:
+        - id
+        - tmdbId
+        - mediaType
+        - score
+        - createdAt
+        - updatedAt
+        - author
+      properties:
+        id:
+          type: integer
+          example: 1
+        tmdbId:
+          type: integer
+          example: 550
+        mediaType:
+          type: string
+          enum: [movie, show]
+          example: movie
+        score:
+          type: integer
+          minimum: 1
+          maximum: 10
+          example: 8
+        createdAt:
+          type: string
+          format: date-time
+          example: "2026-01-01T00:00:00.000Z"
+        updatedAt:
+          type: string
+          format: date-time
+          example: "2026-01-01T00:00:00.000Z"
+        author:
+          type: object
+          required:
+            - id
+            - username
+          properties:
+            id:
+              type: integer
+              example: 1
+            username:
+              type: string
+              example: alice
+
+    RatingListResponse:
+      type: object
+      required:
+        - page
+        - pageSize
+        - totalPages
+        - totalResults
+        - results
+      properties:
+        page:
+          type: integer
+          example: 1
+        pageSize:
+          type: integer
+          example: 10
+        totalPages:
+          type: integer
+          example: 1
+        totalResults:
+          type: integer
+          example: 1
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/RatingResponse'
+
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT obtained from POST /auth/dev-login

--- a/tests/ratings.test.ts
+++ b/tests/ratings.test.ts
@@ -1,0 +1,482 @@
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { app } from '../src/app';
+import { prisma } from '../src/lib/prisma';
+
+// ---------------------------------------------------------------------------
+// Prisma mock — replaces the entire module before any import runs.
+// No database connection is ever attempted.
+// ---------------------------------------------------------------------------
+jest.mock('../src/lib/prisma', () => ({
+  prisma: {
+    rating: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      count: jest.fn(),
+      findMany: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  },
+}));
+
+const mockCreate = prisma.rating.create as jest.Mock;
+const mockFindUnique = prisma.rating.findUnique as jest.Mock;
+const mockUpdate = prisma.rating.update as jest.Mock;
+const mockDelete = prisma.rating.delete as jest.Mock;
+const mockTransaction = prisma.$transaction as jest.Mock;
+
+// ---------------------------------------------------------------------------
+// JWT helper — mints tokens directly without calling dev-login
+// ---------------------------------------------------------------------------
+const TEST_SECRET = 'test-secret';
+
+const makeToken = (userId = 1, role: 'user' | 'admin' = 'user') =>
+  jwt.sign({ sub: userId, email: `user${userId}@test.com`, role }, TEST_SECRET);
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  process.env.TMDB_API_KEY = 'test-api-key';
+  process.env.JWT_SECRET = TEST_SECRET;
+});
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const mockRatingRow = {
+  id: 1,
+  tmdbId: 550,
+  mediaType: 'movie',
+  score: 8,
+  userId: 1,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  user: { id: 1, username: 'alice' },
+};
+
+const expectedRating = {
+  id: 1,
+  tmdbId: 550,
+  mediaType: 'movie',
+  score: 8,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  author: { id: 1, username: 'alice' },
+};
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/ratings
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/ratings', () => {
+  it('200 — returns paginated list with defaults', async () => {
+    mockTransaction.mockResolvedValue([1, [mockRatingRow]]);
+
+    const res = await request(app).get('/api/v1/ratings');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      page: 1,
+      pageSize: 10,
+      totalPages: 1,
+      totalResults: 1,
+      results: [expectedRating],
+    });
+  });
+
+  it('200 — returns empty results when no ratings exist', async () => {
+    mockTransaction.mockResolvedValue([0, []]);
+
+    const res = await request(app).get('/api/v1/ratings');
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toEqual([]);
+    expect(res.body.totalResults).toBe(0);
+    expect(res.body.totalPages).toBe(0);
+  });
+
+  it('200 — accepts tmdbId, mediaType, and userId filters', async () => {
+    mockTransaction.mockResolvedValue([1, [mockRatingRow]]);
+
+    const res = await request(app).get(
+      '/api/v1/ratings?tmdbId=550&mediaType=movie&userId=1'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toHaveLength(1);
+  });
+
+  it('200 — respects custom page and pageSize', async () => {
+    mockTransaction.mockResolvedValue([0, []]);
+
+    const res = await request(app).get('/api/v1/ratings?page=2&pageSize=5');
+
+    expect(res.status).toBe(200);
+    expect(res.body.page).toBe(2);
+    expect(res.body.pageSize).toBe(5);
+  });
+
+  it('400 — non-integer page returns error', async () => {
+    const res = await request(app).get('/api/v1/ratings?page=abc');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — page 0 returns error', async () => {
+    const res = await request(app).get('/api/v1/ratings?page=0');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — pageSize above 50 returns error', async () => {
+    const res = await request(app).get('/api/v1/ratings?pageSize=51');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — invalid mediaType returns error', async () => {
+    const res = await request(app).get('/api/v1/ratings?mediaType=film');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — invalid tmdbId returns error', async () => {
+    const res = await request(app).get('/api/v1/ratings?tmdbId=0');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/ratings
+// ---------------------------------------------------------------------------
+
+describe('POST /api/v1/ratings', () => {
+  it('201 — creates rating and returns transformed response', async () => {
+    mockCreate.mockResolvedValue(mockRatingRow);
+
+    const res = await request(app)
+      .post('/api/v1/ratings')
+      .set('Authorization', `Bearer ${makeToken(1)}`)
+      .send({ tmdbId: 550, mediaType: 'movie', score: 8 });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(expectedRating);
+  });
+
+  it('400 — missing tmdbId returns error', async () => {
+    const res = await request(app)
+      .post('/api/v1/ratings')
+      .set('Authorization', `Bearer ${makeToken(1)}`)
+      .send({ mediaType: 'movie', score: 8 });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — tmdbId of 0 returns error', async () => {
+    const res = await request(app)
+      .post('/api/v1/ratings')
+      .set('Authorization', `Bearer ${makeToken(1)}`)
+      .send({ tmdbId: 0, mediaType: 'movie', score: 8 });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — missing mediaType returns error', async () => {
+    const res = await request(app)
+      .post('/api/v1/ratings')
+      .set('Authorization', `Bearer ${makeToken(1)}`)
+      .send({ tmdbId: 550, score: 8 });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — invalid mediaType returns error', async () => {
+    const res = await request(app)
+      .post('/api/v1/ratings')
+      .set('Authorization', `Bearer ${makeToken(1)}`)
+      .send({ tmdbId: 550, mediaType: 'film', score: 8 });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — missing score returns error', async () => {
+    const res = await request(app)
+      .post('/api/v1/ratings')
+      .set('Authorization', `Bearer ${makeToken(1)}`)
+      .send({ tmdbId: 550, mediaType: 'movie' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — score of 0 returns error', async () => {
+    const res = await request(app)
+      .post('/api/v1/ratings')
+      .set('Authorization', `Bearer ${makeToken(1)}`)
+      .send({ tmdbId: 550, mediaType: 'movie', score: 0 });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — score of 11 returns error', async () => {
+    const res = await request(app)
+      .post('/api/v1/ratings')
+      .set('Authorization', `Bearer ${makeToken(1)}`)
+      .send({ tmdbId: 550, mediaType: 'movie', score: 11 });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — float score returns error', async () => {
+    const res = await request(app)
+      .post('/api/v1/ratings')
+      .set('Authorization', `Bearer ${makeToken(1)}`)
+      .send({ tmdbId: 550, mediaType: 'movie', score: 7.5 });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — string score returns error', async () => {
+    const res = await request(app)
+      .post('/api/v1/ratings')
+      .set('Authorization', `Bearer ${makeToken(1)}`)
+      .send({ tmdbId: 550, mediaType: 'movie', score: '8' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('401 — no Authorization header returns 401', async () => {
+    const res = await request(app)
+      .post('/api/v1/ratings')
+      .send({ tmdbId: 550, mediaType: 'movie', score: 8 });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('401 — malformed token returns 401', async () => {
+    const res = await request(app)
+      .post('/api/v1/ratings')
+      .set('Authorization', 'Bearer not-a-real-token')
+      .send({ tmdbId: 550, mediaType: 'movie', score: 8 });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('409 — duplicate rating returns conflict', async () => {
+    // The controller catches { code: 'P2002' } via the plain-object branch
+    // of isUniqueConstraintError and converts it to 409.
+    mockCreate.mockRejectedValue({ code: 'P2002' });
+
+    const res = await request(app)
+      .post('/api/v1/ratings')
+      .set('Authorization', `Bearer ${makeToken(1)}`)
+      .send({ tmdbId: 550, mediaType: 'movie', score: 8 });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toHaveProperty('error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/ratings/:id
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/ratings/:id', () => {
+  it('200 — returns rating by id', async () => {
+    mockFindUnique.mockResolvedValue(mockRatingRow);
+
+    const res = await request(app).get('/api/v1/ratings/1');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(expectedRating);
+  });
+
+  it('404 — rating does not exist returns 404', async () => {
+    mockFindUnique.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/v1/ratings/9999');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('404 — non-integer id returns 404', async () => {
+    const res = await request(app).get('/api/v1/ratings/abc');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /api/v1/ratings/:id
+// Controller order: auth → parse id → findUnique → assertOwner → parseScore
+// The findUnique mock must be set for any test that reaches the DB call.
+// ---------------------------------------------------------------------------
+
+describe('PUT /api/v1/ratings/:id', () => {
+  it('200 — owner can update score', async () => {
+    const updatedRow = { ...mockRatingRow, score: 9 };
+    mockFindUnique.mockResolvedValue({ id: 1, userId: 1 });
+    mockUpdate.mockResolvedValue(updatedRow);
+
+    const res = await request(app)
+      .put('/api/v1/ratings/1')
+      .set('Authorization', `Bearer ${makeToken(1)}`)
+      .send({ score: 9 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.score).toBe(9);
+    expect(res.body.author).toEqual({ id: 1, username: 'alice' });
+  });
+
+  it('400 — score above 10 returns error', async () => {
+    // Ownership check passes; score validation fires after
+    mockFindUnique.mockResolvedValue({ id: 1, userId: 1 });
+
+    const res = await request(app)
+      .put('/api/v1/ratings/1')
+      .set('Authorization', `Bearer ${makeToken(1)}`)
+      .send({ score: 15 });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('400 — score of 0 returns error', async () => {
+    mockFindUnique.mockResolvedValue({ id: 1, userId: 1 });
+
+    const res = await request(app)
+      .put('/api/v1/ratings/1')
+      .set('Authorization', `Bearer ${makeToken(1)}`)
+      .send({ score: 0 });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('401 — no Authorization header returns 401', async () => {
+    const res = await request(app).put('/api/v1/ratings/1').send({ score: 9 });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('403 — non-owner cannot update rating', async () => {
+    // Rating is owned by user 2; token is for user 1
+    mockFindUnique.mockResolvedValue({ id: 1, userId: 2 });
+
+    const res = await request(app)
+      .put('/api/v1/ratings/1')
+      .set('Authorization', `Bearer ${makeToken(1)}`)
+      .send({ score: 9 });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('404 — rating does not exist returns 404', async () => {
+    mockFindUnique.mockResolvedValue(null);
+
+    const res = await request(app)
+      .put('/api/v1/ratings/9999')
+      .set('Authorization', `Bearer ${makeToken(1)}`)
+      .send({ score: 9 });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('404 — non-integer id returns 404', async () => {
+    const res = await request(app)
+      .put('/api/v1/ratings/abc')
+      .set('Authorization', `Bearer ${makeToken(1)}`)
+      .send({ score: 9 });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/ratings/:id
+// ---------------------------------------------------------------------------
+
+describe('DELETE /api/v1/ratings/:id', () => {
+  it('204 — owner can delete rating', async () => {
+    mockFindUnique.mockResolvedValue({ id: 1, userId: 1 });
+    mockDelete.mockResolvedValue(undefined);
+
+    const res = await request(app)
+      .delete('/api/v1/ratings/1')
+      .set('Authorization', `Bearer ${makeToken(1)}`);
+
+    expect(res.status).toBe(204);
+    expect(res.body).toEqual({});
+  });
+
+  it('401 — no Authorization header returns 401', async () => {
+    const res = await request(app).delete('/api/v1/ratings/1');
+
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('401 — malformed token returns 401', async () => {
+    const res = await request(app)
+      .delete('/api/v1/ratings/1')
+      .set('Authorization', 'Bearer garbage');
+
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('403 — non-owner cannot delete rating', async () => {
+    mockFindUnique.mockResolvedValue({ id: 1, userId: 2 });
+
+    const res = await request(app)
+      .delete('/api/v1/ratings/1')
+      .set('Authorization', `Bearer ${makeToken(1)}`);
+
+    expect(res.status).toBe(403);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('404 — rating does not exist returns 404', async () => {
+    mockFindUnique.mockResolvedValue(null);
+
+    const res = await request(app)
+      .delete('/api/v1/ratings/9999')
+      .set('Authorization', `Bearer ${makeToken(1)}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('404 — non-integer id returns 404', async () => {
+    const res = await request(app)
+      .delete('/api/v1/ratings/abc')
+      .set('Authorization', `Bearer ${makeToken(1)}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+  });
+});


### PR DESCRIPTION
## Summary

- Add 38 Jest/Supertest tests for the ratings vertical slice (all 5 routes: list, create, get, update, delete)
- Add ratings paths, schemas, and BearerAuth security scheme to OpenAPI spec
- Wire JWT middleware and dev-login endpoint for Sprint 2 auth plumbing
- Move v1 show detail handler into its own controller file
- Add v2 tv-shows routes and replace `q` with `title` param in v2 movie/show search

## Test plan

- [ ] `npm test` — 125 tests pass, 0 failures
- [ ] `npm run build` — TypeScript compiles clean
- [ ] `npm run lint` — no ESLint errors
- [ ] `npm run format:check` — Prettier passes
- [ ] Ratings tests cover: 201 create, 200 read/list, 200 update, 204 delete, 400 validation (tmdbId/mediaType/score), 401 missing/invalid token, 403 non-owner, 404 not found, 409 duplicate
- [ ] `GET /api-docs` renders ratings routes with correct request/response shapes and BearerAuth lock icons

\