### PR TITLE
S4-03: add GET /v1/me/ratings — enriched personal ratings list

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -28,6 +28,8 @@ tags:
     description: User review routes for movies and shows
   - name: Issues
     description: Public bug report intake — no authentication required
+  - name: Me
+    description: Authenticated user's own content (ratings, future reviews)
 
 paths:
   /health:
@@ -1075,6 +1077,92 @@ paths:
                   value:
                     error: reproductionSteps must be a string
 
+  /v1/me/ratings:
+    get:
+      tags: [Me]
+      summary: List my ratings
+      description: >
+        Returns a paginated list of the authenticated user's ratings, each enriched with TMDB metadata.
+        The caller is always determined from the JWT — query parameters cannot override identity.
+        If TMDB is unavailable for a given item, the `tmdb` field is `null` rather than failing the whole request.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: page
+          required: false
+          description: Page number (positive integer). Defaults to 1.
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          example: 1
+        - in: query
+          name: pageSize
+          required: false
+          description: Number of results per page (max 50). Defaults to 10.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 10
+          example: 10
+      responses:
+        '200':
+          description: Paginated list of enriched ratings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnrichedRatingListResponse'
+              examples:
+                success:
+                  value:
+                    page: 1
+                    pageSize: 10
+                    totalPages: 1
+                    totalResults: 1
+                    results:
+                      - id: 1
+                        tmdbId: 550
+                        mediaType: movie
+                        score: 8
+                        createdAt: '2026-01-01T00:00:00.000Z'
+                        updatedAt: '2026-01-01T00:00:00.000Z'
+                        author:
+                          id: 1
+                          username: alice
+                        tmdb:
+                          title: Fight Club
+                          year: 1999
+                          posterUrl: https://image.tmdb.org/t/p/w500/poster.jpg
+                          overview: An insomniac office worker crosses paths with a soap maker.
+                tmdbUnavailable:
+                  summary: TMDB upstream failure — tmdb is null
+                  value:
+                    page: 1
+                    pageSize: 10
+                    totalPages: 1
+                    totalResults: 1
+                    results:
+                      - id: 1
+                        tmdbId: 550
+                        mediaType: movie
+                        score: 8
+                        createdAt: '2026-01-01T00:00:00.000Z'
+                        updatedAt: '2026-01-01T00:00:00.000Z'
+                        author:
+                          id: 1
+                          username: alice
+                        tmdb: null
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '500':
+          description: Unexpected server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+
 components:
   securitySchemes:
     bearerAuth:
@@ -1556,3 +1644,70 @@ components:
           minimum: 1
           maximum: 10
           example: 9
+
+    TmdbMeta:
+      type: object
+      nullable: true
+      required:
+        - title
+        - year
+        - posterUrl
+        - overview
+      properties:
+        title:
+          type: string
+          example: Fight Club
+        year:
+          type: integer
+          nullable: true
+          example: 1999
+        posterUrl:
+          type: string
+          nullable: true
+          example: https://image.tmdb.org/t/p/w500/poster.jpg
+        overview:
+          type: string
+          example: An insomniac office worker crosses paths with a soap maker.
+
+    EnrichedRatingResponse:
+      allOf:
+        - $ref: '#/components/schemas/RatingResponse'
+        - type: object
+          required:
+            - tmdbId
+            - tmdb
+          properties:
+            tmdbId:
+              type: integer
+              example: 550
+            tmdb:
+              nullable: true
+              oneOf:
+                - $ref: '#/components/schemas/TmdbMeta'
+                - type: 'null'
+
+    EnrichedRatingListResponse:
+      type: object
+      required:
+        - page
+        - pageSize
+        - totalPages
+        - totalResults
+        - results
+      properties:
+        page:
+          type: integer
+          example: 1
+        pageSize:
+          type: integer
+          example: 10
+        totalPages:
+          type: integer
+          example: 1
+        totalResults:
+          type: integer
+          example: 1
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/EnrichedRatingResponse'

--- a/src/controllers/v1/me.ts
+++ b/src/controllers/v1/me.ts
@@ -1,0 +1,91 @@
+import { Request, Response, NextFunction } from 'express';
+import { prisma } from '../../lib/prisma';
+import { getTmdbConfig } from '../../config/env';
+import { tmdbClient } from '../../services/tmdb-client';
+import { resolveLocalUser } from '../../services/local-user';
+import { HttpError } from '../../errors/http-error';
+import { HTTP_STATUS } from '../../types/api';
+import { buildTmdbImageUrl } from '../../utils/tmdb-image';
+import { extractYear } from '../../utils/extract-year';
+import { parsePaginationQuery } from '../../utils/request-parsing';
+import {
+  toPaginatedResponse,
+  toRatingResponse,
+  userContentAuthorInclude,
+} from '../../transformers/user-content';
+
+interface TmdbMeta {
+  title: string;
+  year: number | null;
+  posterUrl: string | null;
+  overview: string;
+}
+
+const fetchTmdbMeta = async (
+  tmdbId: number,
+  mediaType: 'movie' | 'show'
+): Promise<TmdbMeta | null> => {
+  try {
+    const { imageBaseUrl } = getTmdbConfig();
+    if (mediaType === 'movie') {
+      const data = await tmdbClient.getMovieDetails(tmdbId);
+      return {
+        title: data.title,
+        year: extractYear(data.release_date),
+        posterUrl: buildTmdbImageUrl(imageBaseUrl, data.poster_path, 'w500'),
+        overview: data.overview,
+      };
+    } else {
+      const data = await tmdbClient.getShowDetails(tmdbId);
+      return {
+        title: data.name,
+        year: extractYear(data.first_air_date),
+        posterUrl: buildTmdbImageUrl(imageBaseUrl, data.poster_path, 'w500'),
+        overview: data.overview,
+      };
+    }
+  } catch (error) {
+    console.warn(`TMDB fetch failed for ${mediaType} ${tmdbId}:`, error);
+    return null;
+  }
+};
+
+export const listMyRatings = async (
+  request: Request,
+  response: Response,
+  next: NextFunction
+): Promise<void> => {
+  if (!request.user) {
+    next(new HttpError(HTTP_STATUS.unauthorized, 'Not authenticated'));
+    return;
+  }
+
+  try {
+    const localUser = await resolveLocalUser(request);
+    const { page, pageSize, skip, take } = parsePaginationQuery(
+      request.query as Record<string, unknown>
+    );
+
+    const [totalResults, ratings] = await prisma.$transaction([
+      prisma.rating.count({ where: { userId: localUser.id } }),
+      prisma.rating.findMany({
+        where: { userId: localUser.id },
+        include: userContentAuthorInclude,
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        skip,
+        take,
+      }),
+    ]);
+
+    const results = await Promise.all(
+      ratings.map(async (rating) => ({
+        ...toRatingResponse(rating),
+        tmdb: await fetchTmdbMeta(rating.tmdbId, rating.mediaType),
+      }))
+    );
+
+    response.status(200).json(toPaginatedResponse({ page, pageSize, totalResults, results }));
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/routes/v1/index.ts
+++ b/src/routes/v1/index.ts
@@ -4,6 +4,7 @@ import { moviesRouter } from './movies';
 import { ratingsRouter } from './ratings';
 import { reviewsRouter } from './reviews';
 import { tvShowsRouter } from './tv-shows';
+import { meRouter } from './me';
 
 const router = Router();
 
@@ -12,5 +13,6 @@ router.use('/movies', moviesRouter);
 router.use('/tv-shows', tvShowsRouter);
 router.use('/reviews', reviewsRouter);
 router.use('/ratings', ratingsRouter);
+router.use('/me', meRouter);
 
 export { router as v1Router };

--- a/src/routes/v1/me.ts
+++ b/src/routes/v1/me.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { listMyRatings } from '../../controllers/v1/me';
+import { requireAuth } from '../../middleware/requireAuth';
+
+const router = Router();
+
+router.get('/ratings', requireAuth, listMyRatings);
+
+export { router as meRouter };

--- a/tests/me-ratings.test.ts
+++ b/tests/me-ratings.test.ts
@@ -1,0 +1,176 @@
+import request from 'supertest';
+import { app } from '../src/app';
+import { prisma } from '../src/lib/prisma';
+import { USER_ROLES } from '../src/types/auth';
+import { authHeader, createAccessToken } from './support/auth-fixtures';
+import { buildRatingRecord, buildRatingResponse } from './support/user-content-fixtures';
+
+// ---------------------------------------------------------------------------
+// Prisma mock — no database connection attempted.
+// ---------------------------------------------------------------------------
+jest.mock('../src/lib/prisma', () => ({
+  prisma: {
+    rating: {
+      count: jest.fn(),
+      findMany: jest.fn(),
+    },
+    user: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      create: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  },
+}));
+
+const mockTransaction = prisma.$transaction as jest.Mock;
+const mockUserFindUnique = prisma.user.findUnique as jest.Mock;
+const mockFetch = jest.spyOn(globalThis, 'fetch');
+
+// ---------------------------------------------------------------------------
+// Auth helpers
+// ---------------------------------------------------------------------------
+const makeToken = (userId = 1) =>
+  createAccessToken({ sub: userId, email: `user${userId}@test.com`, role: USER_ROLES.user });
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+const mockRatingRow = buildRatingRecord({ tmdbId: 550, mediaType: 'movie' });
+const baseRatingResponse = buildRatingResponse({ tmdbId: 550, mediaType: 'movie' });
+
+const mockTmdbMovieJson = {
+  id: 550,
+  title: 'Fight Club',
+  overview: 'An insomniac office worker crosses paths with a soap maker.',
+  poster_path: '/poster.jpg',
+  release_date: '1999-10-15',
+  backdrop_path: null,
+  genres: [],
+  runtime: 139,
+  status: 'Released',
+  vote_average: 8.4,
+};
+
+const mockLocalUser = {
+  id: 1,
+  subjectId: 'auth2|test-user-1',
+  username: 'alice',
+  email: 'user1@test.com',
+  firstName: null,
+  lastName: null,
+  role: 'user',
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  process.env.TMDB_API_KEY = 'test-api-key';
+
+  mockUserFindUnique.mockResolvedValue(mockLocalUser);
+
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => mockTmdbMovieJson,
+  } as Response);
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/me/ratings
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/me/ratings', () => {
+  it('200 — returns enriched ratings with tmdb metadata', async () => {
+    mockTransaction.mockResolvedValue([1, [mockRatingRow]]);
+
+    const res = await request(app)
+      .get('/api/v1/me/ratings')
+      .set(authHeader(makeToken(1)));
+
+    expect(res.status).toBe(200);
+    expect(res.body.page).toBe(1);
+    expect(res.body.totalResults).toBe(1);
+    expect(res.body.results).toHaveLength(1);
+
+    const item = res.body.results[0];
+    expect(item).toMatchObject({
+      id: baseRatingResponse.id,
+      score: baseRatingResponse.score,
+      mediaType: 'movie',
+      author: { id: 1, username: 'alice' },
+    });
+    expect(item.tmdb).toMatchObject({
+      title: 'Fight Club',
+      year: 1999,
+      overview: expect.any(String),
+    });
+    expect(item.tmdb.posterUrl).toContain('/poster.jpg');
+  });
+
+  it('200 — ignores ?userId=999 and returns the token caller\'s ratings', async () => {
+    mockTransaction.mockResolvedValue([1, [mockRatingRow]]);
+
+    const res = await request(app)
+      .get('/api/v1/me/ratings?userId=999')
+      .set(authHeader(makeToken(1)));
+
+    expect(res.status).toBe(200);
+    expect(res.body.results[0].author.id).toBe(1);
+    expect(mockTransaction).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({}),
+      ])
+    );
+  });
+
+  it('200 — empty result returns correct envelope', async () => {
+    mockTransaction.mockResolvedValue([0, []]);
+
+    const res = await request(app)
+      .get('/api/v1/me/ratings')
+      .set(authHeader(makeToken(1)));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      page: 1,
+      pageSize: 10,
+      totalPages: 0,
+      totalResults: 0,
+      results: [],
+    });
+  });
+
+  it('200 — TMDB upstream failure returns rating with tmdb: null', async () => {
+    mockTransaction.mockResolvedValue([1, [mockRatingRow]]);
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ status_message: 'Service unavailable' }),
+    } as Response);
+
+    const res = await request(app)
+      .get('/api/v1/me/ratings')
+      .set(authHeader(makeToken(1)));
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toHaveLength(1);
+    expect(res.body.results[0].tmdb).toBeNull();
+  });
+
+  it('401 — missing auth token returns 401', async () => {
+    const res = await request(app).get('/api/v1/me/ratings');
+
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('401 — malformed token returns 401', async () => {
+    const res = await request(app)
+      .get('/api/v1/me/ratings')
+      .set('Authorization', 'Bearer not-a-real-token');
+
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+});


### PR DESCRIPTION
Adds a new /me namespace with a single authenticated route that returns the caller's paginated ratings, each enriched with live TMDB metadata (title, year, posterUrl, overview). TMDB failures per-item degrade gracefully to tmdb: null rather than failing the whole response.

- src/controllers/v1/me.ts: listMyRatings handler + fetchTmdbMeta helper
- src/routes/v1/me.ts: GET /ratings protected by requireAuth
- src/routes/v1/index.ts: mount meRouter at /me
- tests/me-ratings.test.ts: 6 unit tests (Prisma + fetch mocked)
- openapi.yaml: Me tag, /v1/me/ratings path, EnrichedRating* schemas