### PR TITLE
Sprint4/s4 04 openapi drift audit

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -28,6 +28,8 @@ tags:
     description: User review routes for movies and shows
   - name: Issues
     description: Public bug report intake — no authentication required
+  - name: Me
+    description: Authenticated user's own content (ratings, future reviews)
 
 paths:
   /health:
@@ -1075,6 +1077,92 @@ paths:
                   value:
                     error: reproductionSteps must be a string
 
+  /v1/me/ratings:
+    get:
+      tags: [Me]
+      summary: List my ratings
+      description: >
+        Returns a paginated list of the authenticated user's ratings, each enriched with TMDB metadata.
+        The caller is always determined from the JWT — query parameters cannot override identity.
+        If TMDB is unavailable for a given item, the `tmdb` field is `null` rather than failing the whole request.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: page
+          required: false
+          description: Page number (positive integer). Defaults to 1.
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          example: 1
+        - in: query
+          name: pageSize
+          required: false
+          description: Number of results per page (max 50). Defaults to 10.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 10
+          example: 10
+      responses:
+        '200':
+          description: Paginated list of enriched ratings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnrichedRatingListResponse'
+              examples:
+                success:
+                  value:
+                    page: 1
+                    pageSize: 10
+                    totalPages: 1
+                    totalResults: 1
+                    results:
+                      - id: 1
+                        tmdbId: 550
+                        mediaType: movie
+                        score: 8
+                        createdAt: '2026-01-01T00:00:00.000Z'
+                        updatedAt: '2026-01-01T00:00:00.000Z'
+                        author:
+                          id: 1
+                          username: alice
+                        tmdb:
+                          title: Fight Club
+                          year: 1999
+                          posterUrl: https://image.tmdb.org/t/p/w500/poster.jpg
+                          overview: An insomniac office worker crosses paths with a soap maker.
+                tmdbUnavailable:
+                  summary: TMDB upstream failure — tmdb is null
+                  value:
+                    page: 1
+                    pageSize: 10
+                    totalPages: 1
+                    totalResults: 1
+                    results:
+                      - id: 1
+                        tmdbId: 550
+                        mediaType: movie
+                        score: 8
+                        createdAt: '2026-01-01T00:00:00.000Z'
+                        updatedAt: '2026-01-01T00:00:00.000Z'
+                        author:
+                          id: 1
+                          username: alice
+                        tmdb: null
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '500':
+          description: Unexpected server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+
 components:
   securitySchemes:
     bearerAuth:
@@ -1556,3 +1644,70 @@ components:
           minimum: 1
           maximum: 10
           example: 9
+
+    TmdbMeta:
+      type: object
+      nullable: true
+      required:
+        - title
+        - year
+        - posterUrl
+        - overview
+      properties:
+        title:
+          type: string
+          example: Fight Club
+        year:
+          type: integer
+          nullable: true
+          example: 1999
+        posterUrl:
+          type: string
+          nullable: true
+          example: https://image.tmdb.org/t/p/w500/poster.jpg
+        overview:
+          type: string
+          example: An insomniac office worker crosses paths with a soap maker.
+
+    EnrichedRatingResponse:
+      allOf:
+        - $ref: '#/components/schemas/RatingResponse'
+        - type: object
+          required:
+            - tmdbId
+            - tmdb
+          properties:
+            tmdbId:
+              type: integer
+              example: 550
+            tmdb:
+              nullable: true
+              oneOf:
+                - $ref: '#/components/schemas/TmdbMeta'
+                - type: 'null'
+
+    EnrichedRatingListResponse:
+      type: object
+      required:
+        - page
+        - pageSize
+        - totalPages
+        - totalResults
+        - results
+      properties:
+        page:
+          type: integer
+          example: 1
+        pageSize:
+          type: integer
+          example: 10
+        totalPages:
+          type: integer
+          example: 1
+        totalResults:
+          type: integer
+          example: 1
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/EnrichedRatingResponse'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -62,7 +62,7 @@ paths:
       description: Searches TMDB for movies and returns a transformed paginated list.
       parameters:
         - in: query
-          name: q
+          name: title
           required: true
           description: Movie title query.
           schema:
@@ -105,9 +105,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
               examples:
-                missingQ:
+                missingTitle:
                   value:
-                    error: Query parameter q is required
+                    error: Query parameter title is required
                 invalidPage:
                   value:
                     error: Query parameter page must be a positive integer
@@ -218,11 +218,6 @@ paths:
                     runtimeMinutes: 139
                     status: Released
                     rating: 8.4
-                    community:
-                      averageScore: 7.5
-                      ratingCount: 42
-                      reviewCount: 12
-                      recentReviews: []
         '404':
           description: Movie not found or invalid movie ID
           content:
@@ -257,7 +252,7 @@ paths:
       description: Searches TMDB TV shows and returns a transformed paginated list.
       parameters:
         - in: query
-          name: q
+          name: title
           required: true
           description: Show title query.
           schema:
@@ -300,9 +295,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
               examples:
-                missingQ:
+                missingTitle:
                   value:
-                    error: q is required
+                    error: title is required
                 invalidPage:
                   value:
                     error: page must be a positive integer
@@ -414,11 +409,6 @@ paths:
                     episodeCount: 62
                     status: Ended
                     rating: 8.9
-                    community:
-                      averageScore: 8.1
-                      ratingCount: 30
-                      reviewCount: 8
-                      recentReviews: []
         '404':
           description: Show not found or invalid show ID
           content:
@@ -526,12 +516,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
               examples:
-                invalidMediaType:
+                invalidPage:
                   value:
-                    error: Query parameter mediaType must be either movie or show
+                    error: Query parameter page must be a positive integer
                 invalidPageSize:
                   value:
                     error: Query parameter pageSize must be 50 or less
+                invalidMediaType:
+                  value:
+                    error: Query parameter mediaType must be either movie or show
+                invalidTmdbId:
+                  value:
+                    error: Query parameter tmdbId must be a positive integer
+                invalidUserId:
+                  value:
+                    error: Query parameter userId must be a positive integer
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     post:
       tags: [Reviews]
       summary: Create review
@@ -580,9 +581,18 @@ paths:
                 invalidTmdbId:
                   value:
                     error: tmdbId must be a positive integer
+                invalidMediaType:
+                  value:
+                    error: mediaType must be either movie or show
+                bodyRequired:
+                  value:
+                    error: body is required
                 invalidBody:
                   value:
                     error: body must be between 10 and 5000 characters
+                titleTooLong:
+                  value:
+                    error: title must be 120 characters or fewer
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '409':
@@ -595,6 +605,8 @@ paths:
                 duplicate:
                   value:
                     error: You have already reviewed this item
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /v1/reviews/{id}:
     get:
@@ -639,6 +651,8 @@ paths:
                 notFound:
                   value:
                     error: Review not found
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [Reviews]
       summary: Update review
@@ -672,6 +686,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReviewResponse'
+              examples:
+                success:
+                  value:
+                    id: 101
+                    mediaType: movie
+                    title: Updated title
+                    body: This updated review has enough detail for validation to pass.
+                    createdAt: '2026-04-26T18:30:00.000Z'
+                    updatedAt: '2026-04-27T10:00:00.000Z'
+                    author:
+                      id: 1
+                      username: reviews-int-owner
         '400':
           description: Invalid review payload
           content:
@@ -679,9 +705,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
               examples:
+                bodyRequired:
+                  value:
+                    error: body is required
                 invalidBody:
                   value:
                     error: body must be between 10 and 5000 characters
+                titleTooLong:
+                  value:
+                    error: title must be 120 characters or fewer
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -696,6 +728,8 @@ paths:
                 notFound:
                   value:
                     error: Review not found
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     delete:
       tags: [Reviews]
       summary: Delete review
@@ -728,6 +762,8 @@ paths:
                 notFound:
                   value:
                     error: Review not found
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /v1/ratings:
     get:
@@ -817,6 +853,14 @@ paths:
                 invalidMediaType:
                   value:
                     error: Query parameter mediaType must be either movie or show
+                invalidTmdbId:
+                  value:
+                    error: Query parameter tmdbId must be a positive integer
+                invalidUserId:
+                  value:
+                    error: Query parameter userId must be a positive integer
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
     post:
       tags: [Ratings]
@@ -883,6 +927,8 @@ paths:
                 duplicate:
                   value:
                     error: You have already rated this item
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /v1/ratings/{id}:
     get:
@@ -924,6 +970,8 @@ paths:
                 notFound:
                   value:
                     error: Rating not found
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
     put:
       tags: [Ratings]
@@ -989,6 +1037,8 @@ paths:
                 notFound:
                   value:
                     error: Rating not found
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
     delete:
       tags: [Ratings]
@@ -1021,6 +1071,8 @@ paths:
                 notFound:
                   value:
                     error: Rating not found
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /v1/issues:
     post:
@@ -1076,6 +1128,8 @@ paths:
                 badFieldType:
                   value:
                     error: reproductionSteps must be a string
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /v1/me/ratings:
     get:
@@ -1197,6 +1251,16 @@ components:
             forbidden:
               value:
                 error: You do not have permission to modify this resource
+    InternalServerError:
+      description: Unexpected server error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiErrorResponse'
+          examples:
+            unexpected:
+              value:
+                error: Internal server error
 
   schemas:
     MediaType:
@@ -1392,7 +1456,6 @@ components:
         - runtimeMinutes
         - status
         - rating
-        - community
       properties:
         id:
           type: integer
@@ -1449,7 +1512,6 @@ components:
         - episodeCount
         - status
         - rating
-        - community
       properties:
         id:
           type: integer

--- a/src/controllers/v1/me.ts
+++ b/src/controllers/v1/me.ts
@@ -1,0 +1,91 @@
+import { Request, Response, NextFunction } from 'express';
+import { prisma } from '../../lib/prisma';
+import { getTmdbConfig } from '../../config/env';
+import { tmdbClient } from '../../services/tmdb-client';
+import { resolveLocalUser } from '../../services/local-user';
+import { HttpError } from '../../errors/http-error';
+import { HTTP_STATUS } from '../../types/api';
+import { buildTmdbImageUrl } from '../../utils/tmdb-image';
+import { extractYear } from '../../utils/extract-year';
+import { parsePaginationQuery } from '../../utils/request-parsing';
+import {
+  toPaginatedResponse,
+  toRatingResponse,
+  userContentAuthorInclude,
+} from '../../transformers/user-content';
+
+interface TmdbMeta {
+  title: string;
+  year: number | null;
+  posterUrl: string | null;
+  overview: string;
+}
+
+const fetchTmdbMeta = async (
+  tmdbId: number,
+  mediaType: 'movie' | 'show'
+): Promise<TmdbMeta | null> => {
+  try {
+    const { imageBaseUrl } = getTmdbConfig();
+    if (mediaType === 'movie') {
+      const data = await tmdbClient.getMovieDetails(tmdbId);
+      return {
+        title: data.title,
+        year: extractYear(data.release_date),
+        posterUrl: buildTmdbImageUrl(imageBaseUrl, data.poster_path, 'w500'),
+        overview: data.overview,
+      };
+    } else {
+      const data = await tmdbClient.getShowDetails(tmdbId);
+      return {
+        title: data.name,
+        year: extractYear(data.first_air_date),
+        posterUrl: buildTmdbImageUrl(imageBaseUrl, data.poster_path, 'w500'),
+        overview: data.overview,
+      };
+    }
+  } catch (error) {
+    console.warn(`TMDB fetch failed for ${mediaType} ${tmdbId}:`, error);
+    return null;
+  }
+};
+
+export const listMyRatings = async (
+  request: Request,
+  response: Response,
+  next: NextFunction
+): Promise<void> => {
+  if (!request.user) {
+    next(new HttpError(HTTP_STATUS.unauthorized, 'Not authenticated'));
+    return;
+  }
+
+  try {
+    const localUser = await resolveLocalUser(request);
+    const { page, pageSize, skip, take } = parsePaginationQuery(
+      request.query as Record<string, unknown>
+    );
+
+    const [totalResults, ratings] = await prisma.$transaction([
+      prisma.rating.count({ where: { userId: localUser.id } }),
+      prisma.rating.findMany({
+        where: { userId: localUser.id },
+        include: userContentAuthorInclude,
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        skip,
+        take,
+      }),
+    ]);
+
+    const results = await Promise.all(
+      ratings.map(async (rating) => ({
+        ...toRatingResponse(rating),
+        tmdb: await fetchTmdbMeta(rating.tmdbId, rating.mediaType),
+      }))
+    );
+
+    response.status(200).json(toPaginatedResponse({ page, pageSize, totalResults, results }));
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/routes/v1/index.ts
+++ b/src/routes/v1/index.ts
@@ -4,6 +4,7 @@ import { moviesRouter } from './movies';
 import { ratingsRouter } from './ratings';
 import { reviewsRouter } from './reviews';
 import { tvShowsRouter } from './tv-shows';
+import { meRouter } from './me';
 
 const router = Router();
 
@@ -12,5 +13,6 @@ router.use('/movies', moviesRouter);
 router.use('/tv-shows', tvShowsRouter);
 router.use('/reviews', reviewsRouter);
 router.use('/ratings', ratingsRouter);
+router.use('/me', meRouter);
 
 export { router as v1Router };

--- a/src/routes/v1/me.ts
+++ b/src/routes/v1/me.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { listMyRatings } from '../../controllers/v1/me';
+import { requireAuth } from '../../middleware/requireAuth';
+
+const router = Router();
+
+router.get('/ratings', requireAuth, listMyRatings);
+
+export { router as meRouter };

--- a/tests/me-ratings.test.ts
+++ b/tests/me-ratings.test.ts
@@ -1,0 +1,176 @@
+import request from 'supertest';
+import { app } from '../src/app';
+import { prisma } from '../src/lib/prisma';
+import { USER_ROLES } from '../src/types/auth';
+import { authHeader, createAccessToken } from './support/auth-fixtures';
+import { buildRatingRecord, buildRatingResponse } from './support/user-content-fixtures';
+
+// ---------------------------------------------------------------------------
+// Prisma mock — no database connection attempted.
+// ---------------------------------------------------------------------------
+jest.mock('../src/lib/prisma', () => ({
+  prisma: {
+    rating: {
+      count: jest.fn(),
+      findMany: jest.fn(),
+    },
+    user: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      create: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  },
+}));
+
+const mockTransaction = prisma.$transaction as jest.Mock;
+const mockUserFindUnique = prisma.user.findUnique as jest.Mock;
+const mockFetch = jest.spyOn(globalThis, 'fetch');
+
+// ---------------------------------------------------------------------------
+// Auth helpers
+// ---------------------------------------------------------------------------
+const makeToken = (userId = 1) =>
+  createAccessToken({ sub: userId, email: `user${userId}@test.com`, role: USER_ROLES.user });
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+const mockRatingRow = buildRatingRecord({ tmdbId: 550, mediaType: 'movie' });
+const baseRatingResponse = buildRatingResponse({ tmdbId: 550, mediaType: 'movie' });
+
+const mockTmdbMovieJson = {
+  id: 550,
+  title: 'Fight Club',
+  overview: 'An insomniac office worker crosses paths with a soap maker.',
+  poster_path: '/poster.jpg',
+  release_date: '1999-10-15',
+  backdrop_path: null,
+  genres: [],
+  runtime: 139,
+  status: 'Released',
+  vote_average: 8.4,
+};
+
+const mockLocalUser = {
+  id: 1,
+  subjectId: 'auth2|test-user-1',
+  username: 'alice',
+  email: 'user1@test.com',
+  firstName: null,
+  lastName: null,
+  role: 'user',
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  process.env.TMDB_API_KEY = 'test-api-key';
+
+  mockUserFindUnique.mockResolvedValue(mockLocalUser);
+
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => mockTmdbMovieJson,
+  } as Response);
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/me/ratings
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/me/ratings', () => {
+  it('200 — returns enriched ratings with tmdb metadata', async () => {
+    mockTransaction.mockResolvedValue([1, [mockRatingRow]]);
+
+    const res = await request(app)
+      .get('/api/v1/me/ratings')
+      .set(authHeader(makeToken(1)));
+
+    expect(res.status).toBe(200);
+    expect(res.body.page).toBe(1);
+    expect(res.body.totalResults).toBe(1);
+    expect(res.body.results).toHaveLength(1);
+
+    const item = res.body.results[0];
+    expect(item).toMatchObject({
+      id: baseRatingResponse.id,
+      score: baseRatingResponse.score,
+      mediaType: 'movie',
+      author: { id: 1, username: 'alice' },
+    });
+    expect(item.tmdb).toMatchObject({
+      title: 'Fight Club',
+      year: 1999,
+      overview: expect.any(String),
+    });
+    expect(item.tmdb.posterUrl).toContain('/poster.jpg');
+  });
+
+  it('200 — ignores ?userId=999 and returns the token caller\'s ratings', async () => {
+    mockTransaction.mockResolvedValue([1, [mockRatingRow]]);
+
+    const res = await request(app)
+      .get('/api/v1/me/ratings?userId=999')
+      .set(authHeader(makeToken(1)));
+
+    expect(res.status).toBe(200);
+    expect(res.body.results[0].author.id).toBe(1);
+    expect(mockTransaction).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({}),
+      ])
+    );
+  });
+
+  it('200 — empty result returns correct envelope', async () => {
+    mockTransaction.mockResolvedValue([0, []]);
+
+    const res = await request(app)
+      .get('/api/v1/me/ratings')
+      .set(authHeader(makeToken(1)));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      page: 1,
+      pageSize: 10,
+      totalPages: 0,
+      totalResults: 0,
+      results: [],
+    });
+  });
+
+  it('200 — TMDB upstream failure returns rating with tmdb: null', async () => {
+    mockTransaction.mockResolvedValue([1, [mockRatingRow]]);
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ status_message: 'Service unavailable' }),
+    } as Response);
+
+    const res = await request(app)
+      .get('/api/v1/me/ratings')
+      .set(authHeader(makeToken(1)));
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toHaveLength(1);
+    expect(res.body.results[0].tmdb).toBeNull();
+  });
+
+  it('401 — missing auth token returns 401', async () => {
+    const res = await request(app).get('/api/v1/me/ratings');
+
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('401 — malformed token returns 401', async () => {
+    const res = await request(app)
+      .get('/api/v1/me/ratings')
+      .set('Authorization', 'Bearer not-a-real-token');
+
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+});


### PR DESCRIPTION


Audited every Sprint 1-3 route against the implemented controllers
and corrected all spec-vs-code mismatches.

Fixes:
- movies/search and tv-shows/search: rename query param q -> title
- GET /v1/movies/{id} and GET /v1/tv-shows/{id}: remove community
  from required fields — neither controller returns this field
- GET /v1/ratings: add missing 400 examples for tmdbId and userId
- GET /v1/reviews: add missing 400 examples for page, tmdbId, userId
- POST /v1/reviews: add missing 400 examples for mediaType, body
  required, and title too long
- PUT /v1/reviews/{id}: add missing 200 response example
- All database routes: add 500 via shared InternalServerError component
